### PR TITLE
Account for parameters when wrapping avro with documentation

### DIFF
--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -15,9 +15,13 @@
  */
 package com.github.f0xdx;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -82,6 +86,12 @@ public class Schemas {
     // additional initialization (doc, default, optional)
     if (builder != null) {
       builder = builder.name(schema.name()).version(schema.version()).doc(schema.doc());
+
+      if (schema instanceof ConnectSchema) {
+        ConnectSchema connectSchema = (ConnectSchema) schema;
+        Optional<Map<String, String>> params = Optional.ofNullable(connectSchema.parameters());
+        builder = builder.parameters(params.orElseGet(Collections::emptyMap));
+      }
 
       if (schema.defaultValue() != null) {
         builder = builder.defaultValue(schema.defaultValue());

--- a/src/test/java/com/github/f0xdx/SchemasTest.java
+++ b/src/test/java/com/github/f0xdx/SchemasTest.java
@@ -135,4 +135,23 @@ class SchemasTest {
         () -> assertNotNull(result),
         () -> assertEquals(schema, result.build()));
   }
+
+  @DisplayName("schema with parameters")
+  @Test
+  void schemaWithParameters() {
+    val schema =
+        SchemaBuilder.struct()
+            .name("d.struct")
+            .field("str", STRING_SCHEMA)
+            .parameter("connect.doc", "documentation here")
+            .build();
+
+    val result = Schemas.toBuilder(schema);
+    assertAll(
+        "schema builder with parameters",
+        () -> assertNotNull(result),
+        () -> assertEquals(schema.parameters().size(), result.build().parameters().size()),
+        () -> assertTrue(result.build().parameters().containsKey("connect.doc")),
+        () -> assertEquals("documentation here", result.build().parameters().get("connect.doc")));
+  }
 }


### PR DESCRIPTION
I ran into this case when wrapping Avro records that have documentation on them. When converting to a kafka-connect schema, parameters holds a flag that there's documentation on the schema.