### PR TITLE
Add flag for "lifting" the schema version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,13 @@ jobs:
           SONAR_TOKEN: ${{ secrets.sonar_token }}
         run: ./gradlew sonarqube -Dsonar.branch.name=${GITHUB_REF#refs/heads/}
 
+      - name: Package (Confluent Hub Archive)
+        run: |
+          ./gradlew confluent_hub_archive
+          cp build/libs/*.jar build/dist
+
       - name: Generate checksums
-        run: sha256sum build/libs/*.jar > build/libs/checksums.sha256
+        run: sha256sum build/dist/* > build/libs/checksums.sha256
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,40 +11,40 @@ on: [push]
 jobs:
 
   build:
-    name: Build (w/ Gradle)
+    name: Build
     runs-on: ubuntu-latest
 
     steps:
-      - name: checkout repo
+      - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: setup jdk (java 8)
+      - name: Setup jdk (java 8)
         uses: actions/setup-java@v1
         with:
           java-version: 8
 
-      - name: prepare gradle
+      - name: Prepare gradle
         run: chmod +x gradlew
 
-      - name: build (gradle)
+      - name: Build (gradle)
         run: ./gradlew build
 
-      - name: upload test reports (on error)
+      - name: Upload test reports (on error)
         uses: actions/upload-artifact@v1
         if: failure()
         with:
           name: test-reports
           path: build/reports/tests/test
 
-      - name: sonarqube analysis
+      - name: Sonarqube analysis
         env:
           SONAR_TOKEN: ${{ secrets.sonar_token }}
         run: ./gradlew sonarqube -Dsonar.branch.name=${GITHUB_REF#refs/heads/}
 
-      - name: generate checksums
-        run: sha256sum build/libs/*.jar > checksums.sha256
+      - name: Generate checksums
+        run: sha256sum build/libs/*.jar > build/libs/checksums.sha256
 
-      - name: upload artifacts
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v1
         with:
           name: build-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,13 @@ jobs:
       - name: sonarqube analysis
         env:
           SONAR_TOKEN: ${{ secrets.sonar_token }}
-        run: ./gradlew jacocoTestReport sonarqube -Dsonar.branch.name=${GITHUB_REF#refs/heads/}
+        run: ./gradlew sonarqube -Dsonar.branch.name=${GITHUB_REF#refs/heads/}
+
+      - name: generate checksums
+        run: sha256sum build/libs/*.jar > checksums.sha256
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: build-${{ github.run_id }}
+          path: build/libs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
           cp build/libs/*.jar build/dist
 
       - name: Generate checksums
-        run: sha256sum build/dist/* > build/libs/checksums.sha256
+        run: sha256sum build/dist/* > build/dist/checksums.sha256
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v1
         with:
           name: build-${{ github.run_id }}
-          path: build/libs
+          path: build/dist

--- a/README.md
+++ b/README.md
@@ -10,26 +10,20 @@
 The *kafka-connect-wrap-smt* is a [single message transform (SMT)](https://docs.confluent.io/current/connect/transforms/index.html)
 that wraps key and record of kafka messages into a single struct. This ensures, e.g., that data
 contained in complex keys is not lost when ingesting data from kafka in a sink such as
-elasticsearch. Additionally, it supports exporting meta-data such as partition, offset, timestamp,
-topic and kafka headers.
+elasticsearch. Additionally, it supports exporting meta-data including partition, offset, timestamp,
+topic name and kafka headers.
 
 Note that *kafka-connect-wrap-smt* does only support sink connectors, as it wraps kafka specific
 meta-data that is not available for all source connectors.
 
 ## Install
 
-Until we have a fully working github actions build, you can build this project locally using:
+To install the latest release, you can download the plugin binaries directly from github or build
+them from source (see section *Build* below):
 
 ```shell script
-git clone git@github.com:f0xdx/kafka-connect-wrap-smt.git
-./gradlew build
-```
-
-The you will have to deploy the `build/libs/kafka-connect-wrap-smt-0.1-SNAPSHOT.jar` into the
-plugins folder of your kafka connect instance:
-
-```shell script
-cp build/libs/kafka-connect-wrap-smt-0.1-SNAPSHOT.jar connect/plugin/folder
+curl -sLJO https://github.com/f0xdx/kafka-connect-wrap-smt/releases/download/v0.1.0/kafka-connect-wrap-smt-0.1.0.jar
+cp kafka-connect-wrap-smt-0.1-SNAPSHOT.jar connect/plugin/folder
 ```
 
 Make sure that the plugin folder is picked up by kafka connect by verifying its logs. For instance,
@@ -43,7 +37,7 @@ connect            | [2020-03-25 12:48:01,463] INFO Added alias 'Wrap' to plugin
 
 ## Configuration
 
-After installing the plugin, you can configure the SMT as usual with
+After installing the plugin, you can configure your connector to apply the SMT, e.g.:
 
 ```json
 {
@@ -55,6 +49,21 @@ After installing the plugin, you can configure the SMT as usual with
 
 As stated above, this SMT can only be used in conjunction with sink connectors.
 
+## Build
+
+To build this project locally simply run:
+
+```shell script
+git clone git@github.com:f0xdx/kafka-connect-wrap-smt.git
+./gradlew build
+```
+
+After building, you can deploy the `build/libs/kafka-connect-wrap-smt-0.1-SNAPSHOT.jar` into the
+plugins folder of your kafka connect instance, e.g.:
+
+```shell script
+cp build/libs/kafka-connect-wrap-smt-0.1-SNAPSHOT.jar connect/plugin/folder
+```
 
 ## Roadmap
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.time.LocalDate
+
 group = "com.github.f0xdx"
 version = "0.1-SNAPSHOT"
 
@@ -80,5 +82,30 @@ sonarqube {
     property("sonar.organization", "f0xdx")
     property("sonar.host.url", "https://sonarcloud.io")
     property("sonar.login", System.getenv("SONAR_TOKEN"))
+  }
+}
+
+tasks.register<Zip>("confluent_hub_archive") {
+  destinationDirectory.set(file("${buildDir}/dist"))
+  archiveFileName.set("f0xdx-${rootProject.name}-${rootProject.version}.zip")
+
+  from("manifest.json") {
+    expand(
+        "name" to rootProject.name,
+        "version" to rootProject.version,
+        "build_date" to LocalDate.now()
+    )
+  }
+  from("README.md") {
+    into("doc")
+  }
+  from("LICENSE") {
+    into("doc")
+  }
+  from(tasks.javadoc) {
+    into("doc/javadoc")
+  }
+  from(tasks.jar) {
+    into("lib")
   }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,10 @@
 group = "com.github.f0xdx"
 version = "0.1-SNAPSHOT"
 
+val junitVersion by extra("5.6.1")
+val kafkaVersion by extra("2.3.1")
+val lombokVersion by extra("1.18.12")
+
 plugins {
   java
   jacoco
@@ -8,20 +12,9 @@ plugins {
   id("org.sonarqube") version "2.8"
 }
 
-java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
-  withSourcesJar()
-  withJavadocJar()
-}
-
 repositories {
   mavenCentral()
 }
-
-val junitVersion by extra("5.6.1")
-val kafkaVersion by extra("2.3.1")
-val lombokVersion by extra("1.18.12")
 
 dependencies {
   // bom
@@ -58,6 +51,17 @@ tasks.jacocoTestReport {
     xml.isEnabled = true
     csv.isEnabled = false
   }
+}
+
+tasks.sonarqube {
+  dependsOn(tasks.jacocoTestReport)
+}
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+  withSourcesJar()
+  withJavadocJar()
 }
 
 spotless {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 
 group = "com.github.f0xdx"
-version = "0.1-SNAPSHOT"
+version = "0.1.0"
 
 val junitVersion by extra("5.6.2")
 val kafkaVersion by extra("2.3.1")
@@ -108,4 +108,6 @@ tasks.register<Zip>("confluent_hub_archive") {
   from(tasks.jar) {
     into("lib")
   }
+
+  into("f0xdx-${rootProject.name}-${rootProject.version}")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 group = "com.github.f0xdx"
 version = "0.1-SNAPSHOT"
 
-val junitVersion by extra("5.6.1")
+val junitVersion by extra("5.6.2")
 val kafkaVersion by extra("2.3.1")
 val lombokVersion by extra("1.18.12")
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,34 @@
+{
+  "name": "${name}",
+  "version": "${version}",
+  "release_date": "${build_date}",
+  "component_types": ["transform"],
+  "title": "Wrap Transformation",
+  "description": "Kafka Connect single message transform (SMT) wrapping key and record of kafka messages into a single struct. This ensures, e.g., that data contained in complex keys is not lost when ingesting data from kafka in a sink such as elasticsearch. Additionally, it supports exporting meta-data including partition, offset, timestamp, topic name and kafka headers.\n\nNote that this transform does only support sink connectors, as it wraps kafka specific meta-data that is not available for all source connectors.",
+  "owner": {
+    "username": "f0xdx",
+    "name": "Felix Heinrichs",
+    "type": "user",
+    "url": "https://github.com/f0xdx"
+  },
+  "license": [
+    {
+      "name" : "Apache License 2.0",
+      "url" : "https://www.apache.org/licenses/LICENSE-2.0.txt"
+    }
+  ],
+  "source_url": "https://github.com/f0xdx/kafka-connect-wrap-smt",
+  "documentation_url": "https://github.com/f0xdx/kafka-connect-wrap-smt",
+  "support": {
+    "summary": "Support provided through open source community, bugs can be filed as github issues.",
+    "provider_name": "Community",
+    "url": "https://github.com/f0xdx/kafka-connect-wrap-smt/issues"
+  },
+  "tags": ["Key", "Value", "Wrap", "Export"],
+  "features" : {
+    "supported_encodings" : [ "any" ],
+    "single_message_transforms" : true,
+    "confluent_control_center_integration" : false,
+    "kafka_connect_api" : true
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "release_date": "${build_date}",
   "component_types": ["transform"],
   "title": "Wrap Transformation",
-  "description": "Kafka Connect single message transform (SMT) wrapping key and record of kafka messages into a single struct. This ensures, e.g., that data contained in complex keys is not lost when ingesting data from kafka in a sink such as elasticsearch. Additionally, it supports exporting meta-data including partition, offset, timestamp, topic name and kafka headers.\n\nNote that this transform does only support sink connectors, as it wraps kafka specific meta-data that is not available for all source connectors.",
+  "description": "<p>Kafka Connect single message transform (SMT) wrapping key and record of kafka messages into a single struct. This ensures, e.g., that data contained in complex keys is not lost when ingesting data from kafka in a sink such as elasticsearch. Additionally, it supports exporting meta-data including partition, offset, timestamp, topic name and kafka headers.</p><p>Note that this transform does only support <b>sink connectors</b>, as it wraps kafka specific meta-data that is not available for all source connectors.</p>",
   "owner": {
     "username": "f0xdx",
     "name": "Felix Heinrichs",


### PR DESCRIPTION
This PR is to be able to pull the schema version up from either the key or value. This is useful when using this SMT with Arvo and setting "schema.compatibility" to "FULL" on the connector. Without this setting, you'll get `org.apache.kafka.connect.errors.ConnectException: org.apache.kafka.connect.errors.SchemaProjectorException: Schema version required for FULL compatibility`