### PR TITLE
Keep maximum amount of schema while wrapping records

### DIFF
--- a/src/main/java/com/github/f0xdx/Wrap.java
+++ b/src/main/java/com/github/f0xdx/Wrap.java
@@ -15,7 +15,14 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.schemaOf;
+import static com.github.f0xdx.Schemas.toBuilder;
+import static org.apache.kafka.connect.data.SchemaProjector.project;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
+
 import com.github.f0xdx.Schemas.KeyValueSchema;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.*;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
@@ -28,14 +35,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.github.f0xdx.Schemas.schemaOf;
-import static com.github.f0xdx.Schemas.toBuilder;
-import static org.apache.kafka.connect.data.SchemaProjector.project;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
 
 /**
  * Single message transformation (SMT) that wraps key, value and meta-data (partition, offset,

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -15,6 +15,16 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.toBuilder;
+import static com.github.f0xdx.Wrap.*;
+import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
+import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.Map;
 import lombok.val;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -25,17 +35,6 @@ import org.apache.kafka.connect.transforms.util.Requirements;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.Map;
-
-import static com.github.f0xdx.Schemas.toBuilder;
-import static com.github.f0xdx.Wrap.*;
-import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
-import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.*;
 
 class WrapTest {
 


### PR DESCRIPTION
When wrapping records that either have no key or no value but do contain a schema for either of them, we want to make sure to keep most of the schema of the input record.