### PR TITLE
Changed to optional schema in case of null keys/values

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation=true

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -18,6 +18,7 @@ package com.github.f0xdx;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -49,6 +50,14 @@ public class Schemas {
    */
   public static <R extends ConnectRecord<R>> KeyValueSchema schemaOf(@NonNull R record) {
     return KeyValueSchema.of(record.keySchema(), record.valueSchema());
+  }
+
+  public static Schema optionalSchemaOrElse(Schema schema, @NonNull Supplier<Schema> alternative) {
+    return Optional.ofNullable(schema)
+        .map(Schemas::toBuilder)
+        .map(SchemaBuilder::optional)
+        .map(SchemaBuilder::build)
+        .orElseGet(alternative);
   }
 
   /**

--- a/src/test/java/com/github/f0xdx/SchemasTest.java
+++ b/src/test/java/com/github/f0xdx/SchemasTest.java
@@ -17,6 +17,7 @@ package com.github.f0xdx;
 
 import static org.apache.kafka.connect.data.Schema.BOOLEAN_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,6 +58,29 @@ class SchemasTest {
         "schema of",
         () -> assertEquals(STRING_SCHEMA, actual.getKey()),
         () -> assertEquals(BOOLEAN_SCHEMA, actual.getValue()));
+  }
+
+  @DisplayName("derive optional schema")
+  @ParameterizedTest
+  @EnumSource(
+      value = Type.class,
+      names = {"ARRAY", "MAP"},
+      mode = Mode.EXCLUDE)
+  void optionalSchemaOrElse(Type type) {
+    val schema = new SchemaBuilder(type).build();
+    val optionalSchema = new SchemaBuilder(type).optional().build();
+
+    assertAll(
+        "optional schema",
+        () -> assertEquals(optionalSchema, Schemas.optionalSchemaOrElse(schema, () -> null)),
+        () ->
+            assertEquals(optionalSchema, Schemas.optionalSchemaOrElse(optionalSchema, () -> null)));
+  }
+
+  @Test
+  void optionalSchemaOrElseNull() {
+    assertEquals(
+        OPTIONAL_STRING_SCHEMA, Schemas.optionalSchemaOrElse(null, () -> OPTIONAL_STRING_SCHEMA));
   }
 
   @DisplayName("to builder (null value)")

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -17,32 +17,12 @@ package com.github.f0xdx;
 
 import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
 import static com.github.f0xdx.Schemas.toBuilder;
-import static com.github.f0xdx.Wrap.HEADERS;
-import static com.github.f0xdx.Wrap.INCLUDE_HEADERS_CONFIG;
-import static com.github.f0xdx.Wrap.KEY;
-import static com.github.f0xdx.Wrap.OFFSET;
-import static com.github.f0xdx.Wrap.PARTITION;
-import static com.github.f0xdx.Wrap.TIMESTAMP;
-import static com.github.f0xdx.Wrap.TIMESTAMP_TYPE;
-import static com.github.f0xdx.Wrap.TOPIC;
-import static com.github.f0xdx.Wrap.VALUE;
+import static com.github.f0xdx.Wrap.*;
 import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
-import static org.apache.kafka.connect.data.Schema.BOOLEAN_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_BOOLEAN_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.*;
 import static org.apache.kafka.connect.data.Schema.Type.INT32;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
 import java.util.Map;
@@ -81,7 +61,7 @@ class WrapTest {
   @DisplayName("obtain last key schema (no last schema)")
   @Test
   void lastKeySchemaWithoutLastSchema() {
-    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastKeySchema());
+    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastKeySchema("topic"));
   }
 
   @DisplayName("obtain last key schema")
@@ -95,15 +75,13 @@ class WrapTest {
     assertAll(
         "obtained schema",
         () -> assertNotNull(res),
-        () -> assertNotNull(transform.getLastSchema()),
-        () -> assertEquals(res, transform.getLastSchema()),
-        () -> assertEquals(OPTIONAL_INT32_SCHEMA, transform.lastKeySchema()));
+        () -> assertEquals(OPTIONAL_INT32_SCHEMA, transform.lastKeySchema("topic")));
   }
 
   @DisplayName("obtain last value schema (no last schema)")
   @Test
   void lastValueSchemaWithoutLastSchema() {
-    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastValueSchema());
+    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastValueSchema("topic"));
   }
 
   @DisplayName("obtain last value schema")
@@ -116,9 +94,7 @@ class WrapTest {
     assertAll(
         "obtained schema",
         () -> assertNotNull(res),
-        () -> assertNotNull(transform.getLastSchema()),
-        () -> assertEquals(res, transform.getLastSchema()),
-        () -> assertEquals(OPTIONAL_BOOLEAN_SCHEMA, transform.lastValueSchema()));
+        () -> assertEquals(OPTIONAL_BOOLEAN_SCHEMA, transform.lastValueSchema("topic")));
   }
 
   @DisplayName("apply w/o schema (null key)")


### PR DESCRIPTION
Instead of just leaving out the key / or value if it is null, the null value will be added to the resulting wrapped struct. This way we preserve both the information contained within the original schema and the nul value itself. If there is no schema available (null), and both elements are null, we try to guess the schema:

 * either the last schema that was used
 * or a schema simply representing the absence of a value (as a Void schema does not exists, we choose to use `OPTIONAL_STRING_SCHEMA`)