### PR TITLE
Add header schema detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ Upcoming features are:
 
  * CI/CD and automated publishing using github packages
  * install script + docker image for ready made connect
- * typed kafka header export
  * schema based export with schema-less keys (if key schema can be derived)

--- a/src/main/java/com/github/f0xdx/Merger.java
+++ b/src/main/java/com/github/f0xdx/Merger.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 the kafka-connect-wrap-smt authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.f0xdx;
+
+import static com.github.f0xdx.Schemas.toBuilder;
+
+import java.util.*;
+import lombok.NonNull;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
+
+/** Helper class to merge different schemas together. */
+public class Merger {
+  private static final Map<Type, Map<Type, Schema>> mergeMap = new HashMap<>();
+
+  /*
+   * Build a map of mergeable types and the result of a merge.
+   */
+  static {
+    Type[] floatTypes = {Type.FLOAT32, Type.FLOAT64};
+    Schema[] floatSchemas = {Schema.OPTIONAL_FLOAT32_SCHEMA, Schema.OPTIONAL_FLOAT64_SCHEMA};
+    Type[] intTypes = {Type.INT8, Type.INT16, Type.INT32, Type.INT64};
+    Schema[] intSchemas = {
+      Schema.OPTIONAL_INT8_SCHEMA,
+      Schema.OPTIONAL_INT16_SCHEMA,
+      Schema.OPTIONAL_INT32_SCHEMA,
+      Schema.OPTIONAL_INT64_SCHEMA
+    };
+    for (int i = 0; i < floatTypes.length; i++) {
+      for (int j = 0; j < floatTypes.length; j++) {
+        mergeMap
+            .computeIfAbsent(floatTypes[i], (t) -> new HashMap<>())
+            .put(floatTypes[j], floatSchemas[Math.max(i, j)]);
+      }
+    }
+    for (int i = 0; i < intTypes.length; i++) {
+      for (int j = 0; j < intTypes.length; j++) {
+        mergeMap
+            .computeIfAbsent(intTypes[i], (t) -> new HashMap<>())
+            .put(intTypes[j], intSchemas[Math.max(i, j)]);
+      }
+    }
+  }
+
+  private Merger() {}
+
+  public static Schema mergeHeaderSchemas(@NonNull List<Schema> headers) {
+    return headers.stream()
+        .reduce(Merger::mergeSchemas)
+        .map(SchemaBuilder::array)
+        .map(SchemaBuilder::optional)
+        .map(SchemaBuilder::build)
+        .orElseThrow(AssertionError::new);
+  }
+
+  public static Schema mergeSchemas(@NonNull Schema schema, @NonNull Schema addition) {
+    if (schema.equals(addition)) {
+      return schema;
+    }
+
+    if (mergeMap.containsKey(schema.type())
+        && mergeMap.get(schema.type()).containsKey(addition.type())) {
+      return mergeMap.get(schema.type()).get(addition.type());
+    }
+
+    switch (addition.type()) {
+      case STRUCT:
+        if (schema.type() == Type.STRUCT) {
+          return mergeStructs(schema, addition);
+        }
+        break;
+      case MAP:
+        if (schema.type() == Type.MAP) {
+          return SchemaBuilder.map(
+                  mergeSchemas(schema.keySchema(), addition.keySchema()),
+                  mergeSchemas(schema.valueSchema(), addition.valueSchema()))
+              .optional()
+              .build();
+        }
+        break;
+      case ARRAY:
+        if (schema.type() == Type.ARRAY) {
+          return SchemaBuilder.array(mergeSchemas(schema.valueSchema(), addition.valueSchema()))
+              .optional()
+              .build();
+        }
+        break;
+      default:
+        if (Objects.equals(schema.type(), addition.type())) {
+          return Optional.ofNullable(toBuilder(addition))
+              .map(SchemaBuilder::optional)
+              .map(SchemaBuilder::build)
+              .orElseThrow(() -> new DataException("Cannot derive builder for addition schema"));
+        }
+        break;
+    }
+    throw new DataException(
+        "Cannot merge incompatible schemas of type '"
+            + schema.type().getName()
+            + "' and '"
+            + addition.type().getName()
+            + "'.");
+  }
+
+  private static Schema mergeStructs(@NonNull Schema a, @NonNull Schema b) {
+    SchemaBuilder builder = SchemaBuilder.struct();
+    applyStructToBuilder(builder, a);
+    applyStructToBuilder(builder, b);
+    return builder.optional().build();
+  }
+
+  private static void applyStructToBuilder(@NonNull SchemaBuilder builder, @NonNull Schema schema) {
+    for (Field field : schema.fields()) {
+      Field existingField = builder.field(field.name());
+      if (existingField != null) {
+        builder.field(field.name(), mergeSchemas(existingField.schema(), field.schema()));
+      } else {
+        builder.field(field.name(), field.schema());
+      }
+    }
+  }
+}

--- a/src/main/java/com/github/f0xdx/Merger.java
+++ b/src/main/java/com/github/f0xdx/Merger.java
@@ -15,16 +15,15 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.toBuilder;
+
+import java.util.*;
 import lombok.NonNull;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.DataException;
-
-import java.util.*;
-
-import static com.github.f0xdx.Schemas.toBuilder;
 
 /** Helper class to merge different schemas together. */
 class Merger {

--- a/src/main/java/com/github/f0xdx/Merger.java
+++ b/src/main/java/com/github/f0xdx/Merger.java
@@ -15,9 +15,6 @@
  */
 package com.github.f0xdx;
 
-import static com.github.f0xdx.Schemas.toBuilder;
-
-import java.util.*;
 import lombok.NonNull;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
@@ -25,8 +22,12 @@ import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.DataException;
 
+import java.util.*;
+
+import static com.github.f0xdx.Schemas.toBuilder;
+
 /** Helper class to merge different schemas together. */
-public class Merger {
+class Merger {
   private static final Map<Type, Map<Type, Schema>> mergeMap = new HashMap<>();
 
   /*
@@ -60,7 +61,7 @@ public class Merger {
 
   private Merger() {}
 
-  public static Schema mergeHeaderSchemas(@NonNull List<Schema> headers) {
+  static Schema mergeHeaderSchemas(@NonNull List<Schema> headers) {
     return headers.stream()
         .reduce(Merger::mergeSchemas)
         .map(SchemaBuilder::array)
@@ -69,7 +70,7 @@ public class Merger {
         .orElseThrow(AssertionError::new);
   }
 
-  public static Schema mergeSchemas(@NonNull Schema schema, @NonNull Schema addition) {
+  static Schema mergeSchemas(@NonNull Schema schema, @NonNull Schema addition) {
     if (schema.equals(addition)) {
       return schema;
     }
@@ -119,8 +120,8 @@ public class Merger {
   }
 
   private static Schema mergeStructs(@NonNull Schema a, @NonNull Schema b) {
-    SchemaBuilder builder = SchemaBuilder.struct();
-    Map<String, Schema> fields = new HashMap<>();
+    final SchemaBuilder builder = SchemaBuilder.struct();
+    final Map<String, Schema> fields = new HashMap<>();
     applyStructToBuilder(fields, a);
     applyStructToBuilder(fields, b);
     fields.forEach(builder::field);
@@ -130,7 +131,7 @@ public class Merger {
   private static void applyStructToBuilder(
       @NonNull Map<String, Schema> fields, @NonNull Schema schema) {
     for (Field field : schema.fields()) {
-      Schema existing = fields.get(field.name());
+      final Schema existing = fields.get(field.name());
       if (existing != null) {
         fields.put(field.name(), mergeSchemas(existing, field.schema()));
       } else {

--- a/src/main/java/com/github/f0xdx/Merger.java
+++ b/src/main/java/com/github/f0xdx/Merger.java
@@ -15,16 +15,15 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.toBuilder;
+
+import java.util.*;
 import lombok.NonNull;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.DataException;
-
-import java.util.*;
-
-import static com.github.f0xdx.Schemas.toBuilder;
 
 /** Helper class to merge different schemas together. */
 public class Merger {

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -30,6 +30,10 @@ import org.apache.kafka.connect.header.Headers;
 
 /** Helper class for {@link Schema} related tasks. */
 public class Schemas {
+  private static final List<Schema.Type> floatTypes =
+      Arrays.asList(Schema.Type.FLOAT32, Schema.Type.FLOAT64);
+  private static final List<Schema.Type> intTypes =
+      Arrays.asList(Schema.Type.INT8, Schema.Type.INT16, Schema.Type.INT32, Schema.Type.INT64);
 
   /** Wrapper class for unique combinations of schemas. */
   @Value(staticConstructor = "of")
@@ -150,23 +154,21 @@ public class Schemas {
     return SchemaBuilder.array(schema).optional().build();
   }
 
-  private static Schema mergeSchemas(Schema schema, Schema addition) {
+  private static Schema mergeSchemas(Schema schema, @NonNull Schema addition) {
     if (schema == null) {
       return addition;
     }
     switch (addition.type()) {
       case FLOAT32:
       case FLOAT64:
-        if (schema.type().equals(Schema.Type.FLOAT32)
-            || schema.type().equals(Schema.Type.FLOAT64)) {
+        if (floatTypes.contains(schema.type())) {
           return Schema.OPTIONAL_FLOAT64_SCHEMA;
         }
       case INT8:
       case INT16:
       case INT32:
       case INT64:
-        if (Arrays.asList(Schema.Type.INT8, Schema.Type.INT16, Schema.Type.INT32, Schema.Type.INT64)
-            .contains(schema.type())) {
+        if (intTypes.contains(schema.type())) {
           return Schema.OPTIONAL_INT64_SCHEMA;
         }
       case STRUCT:

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -15,9 +15,6 @@
  */
 package com.github.f0xdx;
 
-import java.util.*;
-import java.util.function.Supplier;
-import java.util.stream.StreamSupport;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -27,8 +24,12 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.header.Headers;
 
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
+
 /** Helper class for {@link Schema} related tasks. */
-public class Schemas {
+class Schemas {
   /** Wrapper class for unique combinations of schemas. */
   @Value(staticConstructor = "of")
   public static class SchemaCacheKey {
@@ -49,7 +50,7 @@ public class Schemas {
    * @param <R> a type extending {@link ConnectRecord}
    * @return the {@link SchemaCacheKey} wrapper
    */
-  public static <R extends ConnectRecord<R>> SchemaCacheKey cacheKey(
+  static <R extends ConnectRecord<R>> SchemaCacheKey cacheKey(
       @NonNull R record, boolean includeHeaders) {
     return SchemaCacheKey.of(
         record.keySchema(),
@@ -57,13 +58,13 @@ public class Schemas {
         includeHeaders ? cacheKey(record.headers()) : null);
   }
 
-  public static Map<String, List<Schema>> cacheKey(Headers headers) {
+  static Map<String, List<Schema>> cacheKey(Headers headers) {
     final Map<String, List<Schema>> key = new HashMap<>();
     headers.forEach(h -> key.computeIfAbsent(h.key(), k -> new ArrayList<>()).add(h.schema()));
     return key;
   }
 
-  public static Schema optionalSchemaOrElse(Schema schema, @NonNull Supplier<Schema> alternative) {
+  static Schema optionalSchemaOrElse(Schema schema, @NonNull Supplier<Schema> alternative) {
     return Optional.ofNullable(schema)
         .map(Schemas::toBuilder)
         .map(SchemaBuilder::optional)
@@ -78,7 +79,7 @@ public class Schemas {
    * @param schema the {@link Schema} to convert
    * @return the {@link SchemaBuilder}
    */
-  public static SchemaBuilder toBuilder(@NonNull Schema schema) {
+  static SchemaBuilder toBuilder(@NonNull Schema schema) {
     SchemaBuilder builder = null;
 
     // basic initialization based on type
@@ -131,7 +132,7 @@ public class Schemas {
    * @param headers the message headers (can be null)
    * @return a struct schema for the headers
    */
-  public static Schema forHeaders(Headers headers) {
+  static Schema forHeaders(Headers headers) {
     final SchemaBuilder builder = SchemaBuilder.struct().optional();
     if (headers != null) {
       final Map<String, List<Schema>> schemas = new HashMap<>();

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -15,6 +15,9 @@
  */
 package com.github.f0xdx;
 
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.StreamSupport;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -23,10 +26,6 @@ import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.header.Headers;
-
-import java.util.*;
-import java.util.function.Supplier;
-import java.util.stream.StreamSupport;
 
 /** Helper class for {@link Schema} related tasks. */
 class Schemas {

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -141,7 +141,7 @@ public class Schemas {
     for (Schema headerSchema : headers) {
       schema = mergeSchemas(schema, headerSchema);
     }
-    return schema;
+    return SchemaBuilder.array(schema).optional().build();
   }
 
   private static Schema mergeSchemas(Schema schema, Schema addition) {

--- a/src/main/java/com/github/f0xdx/Wrap.java
+++ b/src/main/java/com/github/f0xdx/Wrap.java
@@ -15,7 +15,16 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
+import static com.github.f0xdx.Schemas.schemaOf;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
+import static org.apache.kafka.connect.data.SchemaProjector.project;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
+
 import com.github.f0xdx.Schemas.KeyValueSchema;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import lombok.*;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
@@ -28,16 +37,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
-import static com.github.f0xdx.Schemas.schemaOf;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
-import static org.apache.kafka.connect.data.SchemaProjector.project;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
 
 /**
  * Single message transformation (SMT) that wraps key, value and meta-data (partition, offset,

--- a/src/main/java/com/github/f0xdx/Wrap.java
+++ b/src/main/java/com/github/f0xdx/Wrap.java
@@ -15,16 +15,7 @@
  */
 package com.github.f0xdx;
 
-import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
-import static com.github.f0xdx.Schemas.schemaOf;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
-import static org.apache.kafka.connect.data.SchemaProjector.project;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
-
 import com.github.f0xdx.Schemas.KeyValueSchema;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import lombok.*;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
@@ -37,6 +28,16 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
+import static com.github.f0xdx.Schemas.schemaOf;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
+import static org.apache.kafka.connect.data.SchemaProjector.project;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
 
 /**
  * Single message transformation (SMT) that wraps key, value and meta-data (partition, offset,
@@ -89,18 +90,17 @@ public class Wrap<R extends ConnectRecord<R>> implements Transformation<R> {
    * @return the {@link Schema} for wrapped records
    */
   synchronized Schema getSchema(@NonNull R record) {
-    val keyValueSchema = schemaOf(record);
+    val keyValueSchema = schemaOf(record, includeHeaders);
     var schema = schemaUpdateCache.get(keyValueSchema);
 
     if (schema == null) { // cache miss
-      schema =
+      val builder =
           SchemaBuilder.struct()
               .field(TOPIC, Schema.STRING_SCHEMA)
               .field(PARTITION, Schema.INT32_SCHEMA)
               .field(OFFSET, Schema.INT64_SCHEMA)
               .field(TIMESTAMP, Schema.INT64_SCHEMA)
               .field(TIMESTAMP_TYPE, Schema.STRING_SCHEMA)
-              .field(HEADERS, SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
               .field(
                   KEY,
                   optionalSchemaOrElse(
@@ -108,8 +108,13 @@ public class Wrap<R extends ConnectRecord<R>> implements Transformation<R> {
               .field(
                   VALUE,
                   optionalSchemaOrElse(
-                      record.valueSchema(), () -> this.lastKeySchema(record.topic())))
-              .build();
+                      record.valueSchema(), () -> this.lastKeySchema(record.topic())));
+
+      if (includeHeaders) {
+        builder.field(HEADERS, Schemas.forHeaders(record.headers()));
+      }
+
+      schema = builder.build();
 
       schemaUpdateCache.put(keyValueSchema, schema);
       topicSchemaCache.put(record.topic(), schema);

--- a/src/main/java/com/github/f0xdx/Wrap.java
+++ b/src/main/java/com/github/f0xdx/Wrap.java
@@ -15,7 +15,15 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.cacheKey;
+import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
+import static org.apache.kafka.connect.data.SchemaProjector.project;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
+
 import com.github.f0xdx.Schemas.SchemaCacheKey;
+import java.util.*;
+import java.util.stream.StreamSupport;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
@@ -32,15 +40,6 @@ import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
-
-import java.util.*;
-import java.util.stream.StreamSupport;
-
-import static com.github.f0xdx.Schemas.cacheKey;
-import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
-import static org.apache.kafka.connect.data.SchemaProjector.project;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
 
 /**
  * Single message transformation (SMT) that wraps key, value and meta-data (partition, offset,

--- a/src/test/java/com/github/f0xdx/MergerTest.java
+++ b/src/test/java/com/github/f0xdx/MergerTest.java
@@ -15,16 +15,15 @@
  */
 package com.github.f0xdx;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class MergerTest {
   private static Type[][] simpleSchemaHappyCases =

--- a/src/test/java/com/github/f0xdx/MergerTest.java
+++ b/src/test/java/com/github/f0xdx/MergerTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2020 the kafka-connect-wrap-smt authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.f0xdx;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MergerTest {
+  private static Type[][] simpleSchemaHappyCases =
+      new Type[][] {
+        new Type[] {Type.FLOAT32, Type.FLOAT32, Type.FLOAT32},
+        new Type[] {Type.FLOAT32, Type.FLOAT64, Type.FLOAT64},
+        new Type[] {Type.INT8, Type.INT8, Type.INT8},
+        new Type[] {Type.INT8, Type.INT16, Type.INT16},
+        new Type[] {Type.INT32, Type.INT8, Type.INT32},
+        new Type[] {Type.INT32, Type.INT8, Type.INT32},
+        new Type[] {Type.INT32, Type.INT64, Type.INT64},
+        new Type[] {Type.BOOLEAN, Type.BOOLEAN, Type.BOOLEAN},
+        new Type[] {Type.STRING, Type.STRING, Type.STRING},
+      };
+  private static Type[][] simpleSchemaFailingCases =
+      new Type[][] {
+        new Type[] {Type.FLOAT32, Type.INT32},
+        new Type[] {Type.FLOAT32, Type.STRING},
+        new Type[] {Type.FLOAT32, Type.STRUCT},
+        new Type[] {Type.STRING, Type.ARRAY},
+        new Type[] {Type.BOOLEAN, Type.INT8},
+      };
+
+  @Test
+  @DisplayName("Simple schema merging works")
+  void testMergeSimpleSchemas() {
+    // Test quick return on equality
+    Schema result = Merger.mergeSchemas(Schema.OPTIONAL_INT8_SCHEMA, Schema.OPTIONAL_INT8_SCHEMA);
+    assertSame(result, Schema.OPTIONAL_INT8_SCHEMA);
+
+    // Test normal merging
+    for (Type[] test : simpleSchemaHappyCases) {
+      testSimpleHappyCase(test[0], test[1], test[2]);
+    }
+    for (Type[] test : simpleSchemaFailingCases) {
+      testSimpleFailingCase(test[0], test[1]);
+    }
+  }
+
+  @Test
+  @DisplayName("Struct schema merging works")
+  void testMergeStructs() {
+    Schema a1 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema a2 = SchemaBuilder.struct().field("b", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema expectedA =
+        SchemaBuilder.struct()
+            .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+    assertEquals(expectedA, Merger.mergeSchemas(a1, a2));
+
+    Schema b1 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT64_SCHEMA).build();
+    Schema b2 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema expectedB =
+        SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT64_SCHEMA).optional().build();
+    assertEquals(expectedB, Merger.mergeSchemas(b1, b2));
+
+    Schema sub = SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT64_SCHEMA).build();
+    Schema c1 = SchemaBuilder.struct().field("a", sub).build();
+    Schema c2 = SchemaBuilder.struct().field("b", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema expectedC =
+        SchemaBuilder.struct()
+            .field("a", sub)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+    assertEquals(expectedC, Merger.mergeSchemas(c1, c2));
+
+    Schema d1 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema d2 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_STRING_SCHEMA).build();
+    assertThrows(DataException.class, () -> Merger.mergeSchemas(d1, d2));
+  }
+
+  @Test
+  @DisplayName("Array schema merging works")
+  void testMergeArrays() {
+    Schema struct1 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema struct2 = SchemaBuilder.struct().field("b", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema a1 = SchemaBuilder.array(struct1);
+    Schema a2 = SchemaBuilder.array(struct2);
+    Schema expectedStruct =
+        SchemaBuilder.struct()
+            .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+    Schema expectedA = SchemaBuilder.array(expectedStruct).optional().build();
+    assertEquals(expectedA, Merger.mergeSchemas(a1, a2));
+
+    Schema b1 = SchemaBuilder.array(Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema b2 = SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).build();
+    Schema expectedB = SchemaBuilder.array(Schema.OPTIONAL_INT64_SCHEMA).optional().build();
+    assertEquals(expectedB, Merger.mergeSchemas(b1, b2));
+
+    Schema c1 = SchemaBuilder.array(Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema c2 = SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build();
+    assertThrows(DataException.class, () -> Merger.mergeSchemas(c1, c2));
+  }
+
+  @Test
+  @DisplayName("Array schema merging works")
+  void testMergeMaps() {
+    Schema struct1 = SchemaBuilder.struct().field("a", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema struct2 = SchemaBuilder.struct().field("b", Schema.OPTIONAL_STRING_SCHEMA).build();
+    Schema a1 = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, struct1);
+    Schema a2 = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, struct2);
+    Schema expectedStruct =
+        SchemaBuilder.struct()
+            .field("a", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build();
+    Schema expectedA =
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, expectedStruct).optional().build();
+    assertEquals(expectedA, Merger.mergeSchemas(a1, a2));
+
+    Schema b1 =
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema b2 =
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA).build();
+    Schema expectedB =
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build();
+    assertEquals(expectedB, Merger.mergeSchemas(b1, b2));
+
+    Schema c1 =
+        SchemaBuilder.map(Schema.OPTIONAL_FLOAT32_SCHEMA, Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema c2 =
+        SchemaBuilder.map(Schema.OPTIONAL_FLOAT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA).build();
+    Schema expectedC =
+        SchemaBuilder.map(Schema.OPTIONAL_FLOAT64_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build();
+    assertEquals(expectedC, Merger.mergeSchemas(c1, c2));
+
+    Schema d1 =
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT8_SCHEMA).build();
+    Schema d2 =
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA).build();
+    assertThrows(DataException.class, () -> Merger.mergeSchemas(d1, d2));
+  }
+
+  @Test
+  @DisplayName("Header schema merging works")
+  void testMergeHeaderSchemas() {
+    Schema a = Schema.OPTIONAL_INT8_SCHEMA;
+    Schema b = Schema.OPTIONAL_INT16_SCHEMA;
+    Schema c = Schema.OPTIONAL_INT32_SCHEMA;
+    Schema expected = SchemaBuilder.array(Schema.OPTIONAL_INT32_SCHEMA).optional().build();
+    assertEquals(expected, Merger.mergeHeaderSchemas(Arrays.asList(a, b, c)));
+
+    assertThrows(
+        DataException.class,
+        () ->
+            Merger.mergeHeaderSchemas(Arrays.asList(Schema.BOOLEAN_SCHEMA, Schema.STRING_SCHEMA)));
+  }
+
+  private void testSimpleHappyCase(Type a, Type b, Type expected) {
+    Schema schemaA = buildSimpleSchema(a, "a");
+    Schema schemaB = buildSimpleSchema(b, "b");
+    Schema result = Merger.mergeSchemas(schemaA, schemaB);
+    assertEquals(expected, result.type());
+    assertTrue(result.isOptional());
+  }
+
+  private void testSimpleFailingCase(Type a, Type b) {
+    Schema schemaA = buildSimpleSchema(a, "a");
+    Schema schemaB = buildSimpleSchema(b, "b");
+    assertThrows(DataException.class, () -> Merger.mergeSchemas(schemaA, schemaB));
+  }
+
+  private Schema buildSimpleSchema(Type type, String doc) {
+    return SchemaBuilder.type(type).doc(doc).optional().build();
+  }
+}

--- a/src/test/java/com/github/f0xdx/SchemasTest.java
+++ b/src/test/java/com/github/f0xdx/SchemasTest.java
@@ -15,18 +15,11 @@
  */
 package com.github.f0xdx;
 
-import static org.apache.kafka.connect.data.Schema.BOOLEAN_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.apache.kafka.connect.data.Schema.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import lombok.val;
-import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.Schema.*;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.DisplayName;
@@ -37,22 +30,22 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 class SchemasTest {
 
-  @DisplayName("key/value schema of (null value)")
+  @DisplayName("cacheKey of (null value)")
   @SuppressWarnings("ConstantConditions")
   @Test
-  void schemaOfNull() {
+  void cacheKeyNull() {
     assertTrue(
-        assertThrows(NullPointerException.class, () -> Schemas.schemaOf(null, false))
+        assertThrows(NullPointerException.class, () -> Schemas.cacheKey(null, false))
             .getMessage()
             .contains("record is marked non-null"));
   }
 
-  @DisplayName("key/value schema of")
+  @DisplayName("cacheKey of")
   @Test
-  void schemaOf() {
+  void cacheKey() {
     val record = new SinkRecord("topic", 0, STRING_SCHEMA, "key", BOOLEAN_SCHEMA, true, 0);
 
-    val actual = Schemas.schemaOf(record, false);
+    val actual = Schemas.cacheKey(record, false);
 
     assertAll(
         "schema of",

--- a/src/test/java/com/github/f0xdx/SchemasTest.java
+++ b/src/test/java/com/github/f0xdx/SchemasTest.java
@@ -42,7 +42,7 @@ class SchemasTest {
   @Test
   void schemaOfNull() {
     assertTrue(
-        assertThrows(NullPointerException.class, () -> Schemas.schemaOf(null))
+        assertThrows(NullPointerException.class, () -> Schemas.schemaOf(null, false))
             .getMessage()
             .contains("record is marked non-null"));
   }
@@ -52,7 +52,7 @@ class SchemasTest {
   void schemaOf() {
     val record = new SinkRecord("topic", 0, STRING_SCHEMA, "key", BOOLEAN_SCHEMA, true, 0);
 
-    val actual = Schemas.schemaOf(record);
+    val actual = Schemas.schemaOf(record, false);
 
     assertAll(
         "schema of",

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -256,7 +256,7 @@ class WrapTest {
         () -> assertNotNull(res.field(TIMESTAMP_TYPE)),
         () -> assertNotNull(res.field(KEY)),
         () -> assertNotNull(res.field(VALUE)),
-        () -> assertNotNull(res.field(HEADERS)),
+        () -> assertNull(res.field(HEADERS)),
         () -> assertEquals(SchemaBuilder.string().optional().build(), res.field(KEY).schema()),
         () -> assertEquals(toBuilder(valueSchema).optional().build(), res.field(VALUE).schema()));
   }
@@ -330,7 +330,7 @@ class WrapTest {
         () -> assertNotNull(res.field(TIMESTAMP_TYPE)),
         () -> assertNotNull(res.field(KEY)),
         () -> assertNotNull(res.field(VALUE)),
-        () -> assertNotNull(res.field(HEADERS)),
+        () -> assertNull(res.field(HEADERS)),
         () -> assertEquals(SchemaBuilder.string().optional().build(), res.field(KEY).schema()),
         () -> assertEquals(toBuilder(valueSchema).optional().build(), res.field(VALUE).schema()));
 

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -15,6 +15,18 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.toBuilder;
+import static com.github.f0xdx.Wrap.*;
+import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
+import static org.apache.kafka.connect.data.Schema.*;
+import static org.apache.kafka.connect.data.Schema.Type.INT32;
+import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.val;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -27,19 +39,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.github.f0xdx.Schemas.toBuilder;
-import static com.github.f0xdx.Wrap.*;
-import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
-import static org.apache.kafka.connect.data.Schema.*;
-import static org.apache.kafka.connect.data.Schema.Type.INT32;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.*;
 
 class WrapTest {
   private static final String TOPIC_VAL = "topic";
@@ -171,31 +170,31 @@ class WrapTest {
                 transformedValue.getStruct("value")));
   }
 
-
   @DisplayName("apply w/ schema and headers")
   @Test
   void applyWithSchemaHeaders() {
     transform.configure(includeHeadersConfig);
-    val valueSchema =
-            SchemaBuilder.struct().field("first", OPTIONAL_STRING_SCHEMA).build();
+    val valueSchema = SchemaBuilder.struct().field("first", OPTIONAL_STRING_SCHEMA).build();
     val value = new Struct(valueSchema);
     val res = applyRecord(STRING_SCHEMA, "key", valueSchema, value);
 
     assertAll(
-            "transformed record",
-            () -> assertNotNull(res.keySchema()),
-            () -> assertNotNull(res.key()),
-            () -> assertEquals("key", res.key()));
+        "transformed record",
+        () -> assertNotNull(res.keySchema()),
+        () -> assertNotNull(res.key()),
+        () -> assertEquals("key", res.key()));
 
     val transformedValue = assertCommonStruct(res);
 
-    Schema headerSchema = SchemaBuilder.struct()
+    Schema headerSchema =
+        SchemaBuilder.struct()
             .field("a", SchemaBuilder.array(STRING_SCHEMA).optional().build())
             .field("b", SchemaBuilder.array(OPTIONAL_INT32_SCHEMA).optional().build())
             .optional()
             .build();
 
-    Struct expectedHeaders = new Struct(headerSchema)
+    Struct expectedHeaders =
+        new Struct(headerSchema)
             .put("a", Collections.singletonList("a"))
             .put("b", Arrays.asList(1, 2));
 


### PR DESCRIPTION
This way, headers will be saved as a Map of String to Array.
Header schemas for each key should be mostly the same, Structs or different numeric precisions can be merged.