### PR TITLE
Release/0.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import java.time.LocalDate
 
 group = "com.github.f0xdx"
-version = "0.1.0"
+version = "0.1.1"
 
 val junitVersion by extra("5.6.2")
 val kafkaVersion by extra("2.3.1")
@@ -10,8 +10,8 @@ val lombokVersion by extra("1.18.12")
 plugins {
   java
   jacoco
-  id("com.diffplug.gradle.spotless") version "3.28.0"
-  id("org.sonarqube") version "2.8"
+  id("com.diffplug.spotless") version "5.1.0"
+  id("org.sonarqube") version "3.0"
 }
 
 repositories {

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation=true

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -18,6 +18,7 @@ package com.github.f0xdx;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -49,6 +50,14 @@ public class Schemas {
    */
   public static <R extends ConnectRecord<R>> KeyValueSchema schemaOf(@NonNull R record) {
     return KeyValueSchema.of(record.keySchema(), record.valueSchema());
+  }
+
+  public static Schema optionalSchemaOrElse(Schema schema, @NonNull Supplier<Schema> alternative) {
+    return Optional.ofNullable(schema)
+        .map(Schemas::toBuilder)
+        .map(SchemaBuilder::optional)
+        .map(SchemaBuilder::build)
+        .orElseGet(alternative);
   }
 
   /**

--- a/src/main/java/com/github/f0xdx/Schemas.java
+++ b/src/main/java/com/github/f0xdx/Schemas.java
@@ -15,9 +15,13 @@
  */
 package com.github.f0xdx;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.Value;
 import org.apache.kafka.connect.connector.ConnectRecord;
+import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -82,6 +86,12 @@ public class Schemas {
     // additional initialization (doc, default, optional)
     if (builder != null) {
       builder = builder.name(schema.name()).version(schema.version()).doc(schema.doc());
+
+      if (schema instanceof ConnectSchema) {
+        ConnectSchema connectSchema = (ConnectSchema) schema;
+        Optional<Map<String, String>> params = Optional.ofNullable(connectSchema.parameters());
+        builder = builder.parameters(params.orElseGet(Collections::emptyMap));
+      }
 
       if (schema.defaultValue() != null) {
         builder = builder.defaultValue(schema.defaultValue());

--- a/src/main/java/com/github/f0xdx/Wrap.java
+++ b/src/main/java/com/github/f0xdx/Wrap.java
@@ -15,7 +15,14 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.schemaOf;
+import static com.github.f0xdx.Schemas.toBuilder;
+import static org.apache.kafka.connect.data.SchemaProjector.project;
+import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
+
 import com.github.f0xdx.Schemas.KeyValueSchema;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.*;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
@@ -28,14 +35,6 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.transforms.Transformation;
 import org.apache.kafka.connect.transforms.util.SimpleConfig;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static com.github.f0xdx.Schemas.schemaOf;
-import static com.github.f0xdx.Schemas.toBuilder;
-import static org.apache.kafka.connect.data.SchemaProjector.project;
-import static org.apache.kafka.connect.transforms.util.Requirements.requireSinkRecord;
 
 /**
  * Single message transformation (SMT) that wraps key, value and meta-data (partition, offset,

--- a/src/test/java/com/github/f0xdx/SchemasTest.java
+++ b/src/test/java/com/github/f0xdx/SchemasTest.java
@@ -17,6 +17,7 @@ package com.github.f0xdx;
 
 import static org.apache.kafka.connect.data.Schema.BOOLEAN_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
 import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,6 +58,29 @@ class SchemasTest {
         "schema of",
         () -> assertEquals(STRING_SCHEMA, actual.getKey()),
         () -> assertEquals(BOOLEAN_SCHEMA, actual.getValue()));
+  }
+
+  @DisplayName("derive optional schema")
+  @ParameterizedTest
+  @EnumSource(
+      value = Type.class,
+      names = {"ARRAY", "MAP"},
+      mode = Mode.EXCLUDE)
+  void optionalSchemaOrElse(Type type) {
+    val schema = new SchemaBuilder(type).build();
+    val optionalSchema = new SchemaBuilder(type).optional().build();
+
+    assertAll(
+        "optional schema",
+        () -> assertEquals(optionalSchema, Schemas.optionalSchemaOrElse(schema, () -> null)),
+        () ->
+            assertEquals(optionalSchema, Schemas.optionalSchemaOrElse(optionalSchema, () -> null)));
+  }
+
+  @Test
+  void optionalSchemaOrElseNull() {
+    assertEquals(
+        OPTIONAL_STRING_SCHEMA, Schemas.optionalSchemaOrElse(null, () -> OPTIONAL_STRING_SCHEMA));
   }
 
   @DisplayName("to builder (null value)")

--- a/src/test/java/com/github/f0xdx/SchemasTest.java
+++ b/src/test/java/com/github/f0xdx/SchemasTest.java
@@ -135,4 +135,23 @@ class SchemasTest {
         () -> assertNotNull(result),
         () -> assertEquals(schema, result.build()));
   }
+
+  @DisplayName("schema with parameters")
+  @Test
+  void schemaWithParameters() {
+    val schema =
+        SchemaBuilder.struct()
+            .name("d.struct")
+            .field("str", STRING_SCHEMA)
+            .parameter("connect.doc", "documentation here")
+            .build();
+
+    val result = Schemas.toBuilder(schema);
+    assertAll(
+        "schema builder with parameters",
+        () -> assertNotNull(result),
+        () -> assertEquals(schema.parameters().size(), result.build().parameters().size()),
+        () -> assertTrue(result.build().parameters().containsKey("connect.doc")),
+        () -> assertEquals("documentation here", result.build().parameters().get("connect.doc")));
+  }
 }

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -15,6 +15,16 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.toBuilder;
+import static com.github.f0xdx.Wrap.*;
+import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
+import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.Map;
 import lombok.val;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -25,17 +35,6 @@ import org.apache.kafka.connect.transforms.util.Requirements;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.Map;
-
-import static com.github.f0xdx.Schemas.toBuilder;
-import static com.github.f0xdx.Wrap.*;
-import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
-import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.*;
 
 class WrapTest {
 

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -17,32 +17,12 @@ package com.github.f0xdx;
 
 import static com.github.f0xdx.Schemas.optionalSchemaOrElse;
 import static com.github.f0xdx.Schemas.toBuilder;
-import static com.github.f0xdx.Wrap.HEADERS;
-import static com.github.f0xdx.Wrap.INCLUDE_HEADERS_CONFIG;
-import static com.github.f0xdx.Wrap.KEY;
-import static com.github.f0xdx.Wrap.OFFSET;
-import static com.github.f0xdx.Wrap.PARTITION;
-import static com.github.f0xdx.Wrap.TIMESTAMP;
-import static com.github.f0xdx.Wrap.TIMESTAMP_TYPE;
-import static com.github.f0xdx.Wrap.TOPIC;
-import static com.github.f0xdx.Wrap.VALUE;
+import static com.github.f0xdx.Wrap.*;
 import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
-import static org.apache.kafka.connect.data.Schema.BOOLEAN_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_BOOLEAN_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_INT32_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.OPTIONAL_STRING_SCHEMA;
-import static org.apache.kafka.connect.data.Schema.STRING_SCHEMA;
+import static org.apache.kafka.connect.data.Schema.*;
 import static org.apache.kafka.connect.data.Schema.Type.INT32;
 import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Collections;
 import java.util.Map;
@@ -81,7 +61,7 @@ class WrapTest {
   @DisplayName("obtain last key schema (no last schema)")
   @Test
   void lastKeySchemaWithoutLastSchema() {
-    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastKeySchema());
+    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastKeySchema("topic"));
   }
 
   @DisplayName("obtain last key schema")
@@ -95,15 +75,13 @@ class WrapTest {
     assertAll(
         "obtained schema",
         () -> assertNotNull(res),
-        () -> assertNotNull(transform.getLastSchema()),
-        () -> assertEquals(res, transform.getLastSchema()),
-        () -> assertEquals(OPTIONAL_INT32_SCHEMA, transform.lastKeySchema()));
+        () -> assertEquals(OPTIONAL_INT32_SCHEMA, transform.lastKeySchema("topic")));
   }
 
   @DisplayName("obtain last value schema (no last schema)")
   @Test
   void lastValueSchemaWithoutLastSchema() {
-    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastValueSchema());
+    assertEquals(OPTIONAL_STRING_SCHEMA, transform.lastValueSchema("topic"));
   }
 
   @DisplayName("obtain last value schema")
@@ -116,9 +94,7 @@ class WrapTest {
     assertAll(
         "obtained schema",
         () -> assertNotNull(res),
-        () -> assertNotNull(transform.getLastSchema()),
-        () -> assertEquals(res, transform.getLastSchema()),
-        () -> assertEquals(OPTIONAL_BOOLEAN_SCHEMA, transform.lastValueSchema()));
+        () -> assertEquals(OPTIONAL_BOOLEAN_SCHEMA, transform.lastValueSchema("topic")));
   }
 
   @DisplayName("apply w/o schema (null key)")

--- a/src/test/java/com/github/f0xdx/WrapTest.java
+++ b/src/test/java/com/github/f0xdx/WrapTest.java
@@ -15,6 +15,16 @@
  */
 package com.github.f0xdx;
 
+import static com.github.f0xdx.Schemas.toBuilder;
+import static com.github.f0xdx.Wrap.*;
+import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
+import static org.apache.kafka.connect.data.Schema.*;
+import static org.apache.kafka.connect.data.Schema.Type.INT32;
+import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Collections;
+import java.util.Map;
 import lombok.val;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -26,17 +36,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.Map;
-
-import static com.github.f0xdx.Schemas.toBuilder;
-import static com.github.f0xdx.Wrap.*;
-import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
-import static org.apache.kafka.connect.data.Schema.*;
-import static org.apache.kafka.connect.data.Schema.Type.INT32;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
-import static org.junit.jupiter.api.Assertions.*;
 
 class WrapTest {
   private static final String TOPIC_VAL = "topic";


### PR DESCRIPTION
PR for 0.1.1 release:

 * additional schema parameters are preserved while wrapping
 * missing schema of null keys / values is extrapolated